### PR TITLE
Fix read handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = function(from, mnt) {
   handlers.read = function(pathname, offset, len, buf, handle, cb) {
     fs.read(handle, buf, 0, len, offset, function(err, bytes) {
       if (err) return cb(-errno(err))
-      cb(0, bytes)
+      cb(bytes)
     })
   }
 


### PR DESCRIPTION
The callback from the read handler should be called with the length of the read data as a first and only argument. The current implementation always returns empty files
